### PR TITLE
Change order of spi send and read 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,8 @@ where
             block!({
                 // Some implementations (stm32f0xx-hal) want a matching read
                 // We don't want to block so we just hope it's ok this way
-                self.spi.read().ok();
-                self.spi.send(patterns[bits as usize])
+                self.spi.send(patterns[bits as usize]);
+                self.spi.read()
             })?;
             data <<= 2;
         }
@@ -111,8 +111,10 @@ where
 
     fn flush(&mut self) -> Result<(), E> {
         for _ in 0..20 {
-            block!(self.spi.send(0))?;
-            self.spi.read().ok();
+            block!({
+                self.spi.send(0);
+                self.spi.read()
+            })?;
         }
         Ok(())
     }


### PR DESCRIPTION
Hey

I had trouble using SPI with my strip, constantly getting Overrun errors after a first successful write. After som trial and error guesswork, I made it work with the following changes to the lib. 

Maybe it needs a config flag if it works differently for other hardware.. 
(I'm using stm32f4xx_hal on a STM32F401CEUx, the strip is just called "ws2812b led strip" (from "BTF-lighting"))
