### PR TITLE
Improve the FIFO handling, so there are less overrun errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Modify `FullDuplex` FIFO handling to be more resilient
 
 ## [0.3.0] - 2020-02-09
 ### Added


### PR DESCRIPTION
Fixes the `Overrun` error & is less hacky when exploiting the FIFO.

Platforms I (might) check (and add the resulting code to the examples repo):
- [x] AVR?
  - It's a bit too slow at 16MHz (might work when overclocking to 24MHz), but the interesting bits work
- [x] atsamd
- [x] lpc845
- [x] stm32f0
- [x] stm32f1
- [ ] stm32f3
- [ ] stm32g0
- [ ] nrf51
- [ ] ....