### PR TITLE
Switch `prerendered` to use the same bit patterns as the normal variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- SK812w support for the `prerendered` variant
+
 ### Changed
 - Modify `FullDuplex` FIFO handling to be more resilient
+- Switch `prerendered` to use the same bit patterns as the normal variant
+
+  This removes the ability to use custom frequencies, but makes the whole code a
+  *lot* simpler & more like the normal variant.
 
 ## [0.3.0] - 2020-02-09
 ### Added


### PR DESCRIPTION
This makes the code much simpler, but constrains the available frequencies (but even the AVR spi peripheral has enough prescaler options).


Nice-to-have features, PRs welcome:
- Add an option to use `spi::blocking::Write`, if it's properly implemented
- If the `mosi_idle_high` option isn't activated, the flush can be done separately, decreasing the buffer size by 20 bytes

Might be of interest to @rahix, I've added an avr example in https://github.com/smart-leds-rs/smart-leds-samples/pull/7 using avr-hal