### PR TITLE
Add `hosted` variant intended for linux SBCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add a `hosted` variant intended for SBCs where the whole data transmission needs to be done in a single call
 
 ### Changed
 - Increased reset time from ~50μs to ~300μs, to deal with more/newer variants

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ embedded-hal = "1.0.0"
 
 [features]
 mosi_idle_high = []
+std = []

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ It provides three variants:
   spi data.
 - Hosted
 
-  Intended for device like the raspberry pi or other linux SBCs. Similarly to
+  Intended for device like the Raspberry Pi or other Linux SBCs. Similarly to
   prerendered it creates all the data beforehand, but sends it using a single
   call.
+
 ## It doesn't work!!!
 - Do you use the normal variant? Does your spi run at the right frequency?
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An embedded-hal driver for ws2812 leds using spi as the timing provider.
 
 ![rainbow on stm32f0](./stm32f0_ws2812_spi_rainbow.gif)
 
-It provides two variants:
+It provides three variants:
 - The normal usage
 
   Your spi peripheral has to run betwee 2MHz and 3.8MHz & the SPI data is created on-the-fly.
@@ -18,7 +18,11 @@ It provides two variants:
   may want to use this. It creates all the data beforehand & then sends it. This
   means that you have to provide a data array that's large enough for all the
   spi data.
+- Hosted
 
+  Intended for device like the raspberry pi or other linux SBCs. Similarly to
+  prerendered it creates all the data beforehand, but sends it using a single
+  call.
 ## It doesn't work!!!
 - Do you use the normal variant? Does your spi run at the right frequency?
 

--- a/src/hosted.rs
+++ b/src/hosted.rs
@@ -7,8 +7,7 @@
 
 use embedded_hal as hal;
 
-use hal::blocking::spi::Write;
-use hal::spi::{Mode, Phase, Polarity};
+use hal::spi::{Mode, Phase, Polarity, SpiBus};
 
 use core::marker::PhantomData;
 
@@ -39,7 +38,7 @@ pub struct Ws2812<SPI, DEVICE = devices::Ws2812> {
 
 impl<SPI, E> Ws2812<SPI>
 where
-    SPI: Write<u8, Error = E>,
+    SPI: SpiBus<u8, Error = E>,
 {
     /// Use ws2812 devices via spi
     ///
@@ -60,7 +59,7 @@ where
 
 impl<SPI, E> Ws2812<SPI, devices::Sk6812w>
 where
-    SPI: Write<u8, Error = E>,
+    SPI: SpiBus<u8, Error = E>,
 {
     /// Use sk6812w devices via spi
     ///
@@ -83,7 +82,7 @@ where
 
 impl<SPI, D, E> Ws2812<SPI, D>
 where
-    SPI: Write<u8, Error = E>,
+    SPI: SpiBus<u8, Error = E>,
 {
     /// Write a single byte for ws2812 devices
     fn write_byte(&mut self, mut data: u8) {
@@ -108,14 +107,14 @@ where
 
 impl<SPI, E> SmartLedsWrite for Ws2812<SPI>
 where
-    SPI: Write<u8, Error = E>,
+    SPI: SpiBus<u8, Error = E>,
 {
     type Error = E;
     type Color = RGB8;
     /// Write all the items of an iterator to a ws2812 strip
     fn write<T, I>(&mut self, iterator: T) -> Result<(), E>
     where
-        T: Iterator<Item = I>,
+        T: IntoIterator<Item = I>,
         I: Into<Self::Color>,
     {
         for item in iterator {
@@ -130,14 +129,14 @@ where
 
 impl<SPI, E> SmartLedsWrite for Ws2812<SPI, devices::Sk6812w>
 where
-    SPI: Write<u8, Error = E>,
+    SPI: SpiBus<u8, Error = E>,
 {
     type Error = E;
     type Color = RGBW<u8, u8>;
-    /// Write all the items of an iterator to a sk6812w strip
+    /// Write all the items of an iterator to a ws2812 strip
     fn write<T, I>(&mut self, iterator: T) -> Result<(), E>
     where
-        T: Iterator<Item = I>,
+        T: IntoIterator<Item = I>,
         I: Into<Self::Color>,
     {
         for item in iterator {

--- a/src/hosted.rs
+++ b/src/hosted.rs
@@ -1,4 +1,4 @@
-//! # Use ws2812 leds via spi on linux hosts
+//! # Use WS2812 LEDs via SPI on Linux hosts
 //!
 //! This dynamically allocates an output buffer and writes out the data in a single call.
 //! Much better suited for linux or similar environments, but may not always work

--- a/src/hosted.rs
+++ b/src/hosted.rs
@@ -1,32 +1,18 @@
-//! # Use ws2812 leds via spi
+//! This dynamically allocates an output buffer and writes out the data in a single call
 //!
-//! - For usage with `smart-leds`
-//! - Implements the `SmartLedsWrite` trait
-//!
-//! Needs a type implementing the `spi::SpiBus` trait.
-//!
-//! The spi peripheral should run at 2MHz to 3.8 MHz
-
-// Timings for ws2812 from https://cpldcpu.files.wordpress.com/2014/01/ws2812_timing_table.png
-// Timings for sk6812 from https://cpldcpu.wordpress.com/2016/03/09/the-sk6812-another-intelligent-rgb-led/
-
-#![no_std]
-
-#[cfg(feature = "std")]
-extern crate std;
+//! Much better suited for linux or similar environments
 
 use embedded_hal as hal;
 
-#[cfg(feature = "std")]
-pub mod hosted;
-pub mod prerendered;
-
-use hal::spi::{Mode, Phase, Polarity, SpiBus};
+use hal::blocking::spi::Write;
+use hal::spi::{Mode, Phase, Polarity};
 
 use core::marker::PhantomData;
-use core::slice::from_ref;
 
 use smart_leds_trait::{SmartLedsWrite, RGB8, RGBW};
+
+use std::vec;
+use std::vec::Vec;
 
 /// SPI mode that can be used for this crate
 ///
@@ -44,12 +30,13 @@ pub mod devices {
 
 pub struct Ws2812<SPI, DEVICE = devices::Ws2812> {
     spi: SPI,
+    data: Vec<u8>,
     device: PhantomData<DEVICE>,
 }
 
 impl<SPI, E> Ws2812<SPI>
 where
-    SPI: SpiBus<u8, Error = E>,
+    SPI: Write<u8, Error = E>,
 {
     /// Use ws2812 devices via spi
     ///
@@ -57,11 +44,16 @@ where
     ///
     /// You may need to look at the datasheet and your own hal to verify this.
     ///
-    /// Please ensure that the mcu is pretty fast, otherwise weird timing
-    /// issues will occur
     pub fn new(spi: SPI) -> Self {
+        let data = if cfg!(feature = "mosi_idle_high") {
+            vec![0; 140]
+        } else {
+            vec![]
+        };
+
         Self {
             spi,
+            data,
             device: PhantomData {},
         }
     }
@@ -69,7 +61,7 @@ where
 
 impl<SPI, E> Ws2812<SPI, devices::Sk6812w>
 where
-    SPI: SpiBus<u8, Error = E>,
+    SPI: Write<u8, Error = E>,
 {
     /// Use sk6812w devices via spi
     ///
@@ -77,13 +69,18 @@ where
     ///
     /// You may need to look at the datasheet and your own hal to verify this.
     ///
-    /// Please ensure that the mcu is pretty fast, otherwise weird timing
-    /// issues will occur
     // The spi frequencies are just the limits, the available timing data isn't
     // complete
     pub fn new_sk6812w(spi: SPI) -> Self {
+        let data = if cfg!(feature = "mosi_idle_high") {
+            vec![0; 140]
+        } else {
+            vec![]
+        };
+
         Self {
             spi,
+            data,
             device: PhantomData {},
         }
     }
@@ -91,82 +88,74 @@ where
 
 impl<SPI, D, E> Ws2812<SPI, D>
 where
-    SPI: SpiBus<u8, Error = E>,
+    SPI: Write<u8, Error = E>,
 {
     /// Write a single byte for ws2812 devices
-    fn write_byte(&mut self, mut data: u8) -> Result<(), E> {
+    fn write_byte(&mut self, mut data: u8) {
         // Send two bits in one spi byte. High time first, then the low time
         // The maximum for T0H is 500ns, the minimum for one bit 1063 ns.
         // These result in the upper and lower spi frequency limits
         let patterns = [0b1000_1000, 0b1000_1110, 0b11101000, 0b11101110];
         for _ in 0..4 {
             let bits = (data & 0b1100_0000) >> 6;
-            self.spi.write(from_ref(&patterns[bits as usize]))?;
+            self.data.push(patterns[bits as usize]);
             data <<= 2;
         }
-        Ok(())
     }
 
-    fn flush(&mut self) -> Result<(), E> {
-        // Should be > 300μs, so for an SPI Freq. of 3.8MHz, we have to send at least 1140 low bits or 140 low bytes
-        for _ in 0..140 {
-            self.spi.write(from_ref(&0))?;
-        }
+    fn send_data(&mut self) -> Result<(), E> {
+        self.data.extend_from_slice(&[0; 140]);
+        self.spi.write(&self.data)?;
+        self.data.truncate(if cfg!(feature = "mosi_idle_high") {
+            140
+        } else {
+            0
+        });
         Ok(())
     }
 }
 
 impl<SPI, E> SmartLedsWrite for Ws2812<SPI>
 where
-    SPI: SpiBus<u8, Error = E>,
+    SPI: Write<u8, Error = E>,
 {
     type Error = E;
     type Color = RGB8;
     /// Write all the items of an iterator to a ws2812 strip
     fn write<T, I>(&mut self, iterator: T) -> Result<(), E>
     where
-        T: IntoIterator<Item = I>,
+        T: Iterator<Item = I>,
         I: Into<Self::Color>,
     {
-        if cfg!(feature = "mosi_idle_high") {
-            self.flush()?;
-        }
-
         for item in iterator {
             let item = item.into();
-            self.write_byte(item.g)?;
-            self.write_byte(item.r)?;
-            self.write_byte(item.b)?;
+            self.write_byte(item.g);
+            self.write_byte(item.r);
+            self.write_byte(item.b);
         }
-        self.flush()?;
-        Ok(())
+        self.send_data()
     }
 }
 
 impl<SPI, E> SmartLedsWrite for Ws2812<SPI, devices::Sk6812w>
 where
-    SPI: SpiBus<u8, Error = E>,
+    SPI: Write<u8, Error = E>,
 {
     type Error = E;
     type Color = RGBW<u8, u8>;
-    /// Write all the items of an iterator to a ws2812 strip
+    /// Write all the items of an iterator to a sk6812w strip
     fn write<T, I>(&mut self, iterator: T) -> Result<(), E>
     where
-        T: IntoIterator<Item = I>,
+        T: Iterator<Item = I>,
         I: Into<Self::Color>,
     {
-        if cfg!(feature = "mosi_idle_high") {
-            self.flush()?;
-        }
-
         for item in iterator {
             let item = item.into();
-            self.write_byte(item.g)?;
-            self.write_byte(item.r)?;
-            self.write_byte(item.b)?;
-            self.write_byte(item.a.0)?;
+            self.write_byte(item.g);
+            self.write_byte(item.r);
+            self.write_byte(item.b);
+            self.write_byte(item.a.0);
         }
-        self.flush()?;
-        Ok(())
+        self.send_data()
     }
 }

--- a/src/hosted.rs
+++ b/src/hosted.rs
@@ -1,6 +1,9 @@
-//! This dynamically allocates an output buffer and writes out the data in a single call
+//! # Use ws2812 leds via spi on linux hosts
 //!
-//! Much better suited for linux or similar environments
+//! This dynamically allocates an output buffer and writes out the data in a single call.
+//! Much better suited for linux or similar environments, but may not always work
+//!
+//! Intendded for use with rppal or linux-embedded-hal
 
 use embedded_hal as hal;
 

--- a/src/hosted.rs
+++ b/src/hosted.rs
@@ -48,11 +48,7 @@ where
     /// You may need to look at the datasheet and your own hal to verify this.
     ///
     pub fn new(spi: SPI) -> Self {
-        let data = if cfg!(feature = "mosi_idle_high") {
-            vec![0; 140]
-        } else {
-            vec![]
-        };
+        let data = vec![0; 140];
 
         Self {
             spi,
@@ -75,11 +71,7 @@ where
     // The spi frequencies are just the limits, the available timing data isn't
     // complete
     pub fn new_sk6812w(spi: SPI) -> Self {
-        let data = if cfg!(feature = "mosi_idle_high") {
-            vec![0; 140]
-        } else {
-            vec![]
-        };
+        let data = vec![0; 140];
 
         Self {
             spi,
@@ -109,11 +101,7 @@ where
     fn send_data(&mut self) -> Result<(), E> {
         self.data.extend_from_slice(&[0; 140]);
         self.spi.write(&self.data)?;
-        self.data.truncate(if cfg!(feature = "mosi_idle_high") {
-            140
-        } else {
-            0
-        });
+        self.data.truncate(140);
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,7 @@
 // Timings for ws2812 from https://cpldcpu.files.wordpress.com/2014/01/ws2812_timing_table.png
 // Timings for sk6812 from https://cpldcpu.wordpress.com/2016/03/09/the-sk6812-another-intelligent-rgb-led/
 
-#![no_std]
-
-#[cfg(feature = "std")]
-extern crate std;
+#![cfg_attr(not(feature = "std"), no_std)]
 
 use embedded_hal as hal;
 


### PR DESCRIPTION
Intended for applications like https://github.com/smart-leds-rs/ws2812-spi-rs/issues/26. 

Can be used instead of [ws281x-rpi driver](https://github.com/nathansamson/ws281x-rpi) as a pure rust solution in combination with rppal, but not as flexible and tested.

Needs some documentation.

