### PR TITLE
Use embedded_hal::blocking::spi::Write instead of FullDuplex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ readme = "README.md"
 repository = "https://github.com/smart-leds-rs/ws2812-spi-rs"
 
 [dependencies]
-nb = "0.1.3"
 smart-leds-trait = "0.2.0"
 embedded-hal = "0.2.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ws2812-spi"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["David Sawatzke <david-sawatzke@users.noreply.github.com>"]
 edition = "2018"
 categories = [

--- a/src/prerendered.rs
+++ b/src/prerendered.rs
@@ -5,14 +5,13 @@
 
 use embedded_hal as hal;
 
-use hal::spi::{FullDuplex, Mode, Phase, Polarity};
+use hal::spi::{Mode, Phase, Polarity};
+use hal::blocking::spi::Write;
 
 use core::marker::PhantomData;
 
 use smart_leds_trait::{SmartLedsWrite, RGB8, RGBW};
 
-use nb;
-use nb::block;
 
 /// SPI mode that can be used for this crate
 ///
@@ -37,7 +36,7 @@ pub struct Ws2812<'a, SPI, DEVICE = devices::Ws2812> {
 
 impl<'a, SPI, E> Ws2812<'a, SPI>
 where
-    SPI: FullDuplex<u8, Error = E>,
+    SPI: Write<u8, Error = E>,
 {
     /// Use ws2812 devices via spi
     ///
@@ -62,7 +61,7 @@ where
 
 impl<'a, SPI, E> Ws2812<'a, SPI, devices::Sk6812w>
 where
-    SPI: FullDuplex<u8, Error = E>,
+    SPI: Write<u8, Error = E>,
 {
     /// Use sk6812w devices via spi
     ///
@@ -89,7 +88,7 @@ where
 
 impl<'a, SPI, D, E> Ws2812<'a, SPI, D>
 where
-    SPI: FullDuplex<u8, Error = E>,
+    SPI: Write<u8, Error = E>,
 {
     /// Write a single byte for ws2812 devices
     fn write_byte(&mut self, mut data: u8) {
@@ -109,30 +108,23 @@ where
         // We introduce an offset in the fifo here, so there's always one byte in transit
         // Some MCUs (like the stm32f1) only a one byte fifo, which would result
         // in overrun error if two bytes need to be stored
-        block!(self.spi.send(0))?;
+        self.spi.write(&[0u8])?;
         if cfg!(feature = "mosi_idle_high") {
             for _ in 0..140 {
-                block!(self.spi.send(0))?;
-                block!(self.spi.read())?;
+                self.spi.write(&[0u8])?;
             }
         }
-        for b in self.data[..self.index].iter() {
-            block!(self.spi.send(*b))?;
-            block!(self.spi.read())?;
-        }
+        self.spi.write(&self.data[..self.index])?;
         for _ in 0..140 {
-            block!(self.spi.send(0))?;
-            block!(self.spi.read())?;
+           self.spi.write(&[0u8])?;
         }
-        // Now, resolve the offset we introduced at the beginning
-        block!(self.spi.read())?;
         Ok(())
     }
 }
 
 impl<'a, SPI, E> SmartLedsWrite for Ws2812<'a, SPI>
 where
-    SPI: FullDuplex<u8, Error = E>,
+    SPI: Write<u8, Error = E>,
 {
     type Error = E;
     type Color = RGB8;
@@ -156,7 +148,7 @@ where
 
 impl<'a, SPI, E> SmartLedsWrite for Ws2812<'a, SPI, devices::Sk6812w>
 where
-    SPI: FullDuplex<u8, Error = E>,
+    SPI: Write<u8, Error = E>,
 {
     type Error = E;
     type Color = RGBW<u8, u8>;


### PR DESCRIPTION
## Issue description

Trying to compile the stm32f0 examples results in an error because `embedded_hal::spi::FullDuplex` is not implemented for SPI on stm32f0xx_hal:


```
error[E0277]: the trait bound `Spi<stm32f0xx_hal::pac::SPI1, stm32f0xx_hal::gpio::gpioa::PA5<Alternate<stm32f0xx_hal::gpio::AF0>>, stm32f0xx_hal::gpio::gpioa::PA6<Alternate<stm32f0xx_hal::gpio::AF0>>, stm32f0xx_hal::gpio::gpioa::PA7<Alternate<stm32f0xx_hal::gpio::AF0>>, EightBit>: _embedded_hal_spi_FullDuplex<u8>` is not satisfied
  --> examples/stm32f0_ws2812_spi_blink.rs:54:34
   |
54 |         let mut ws = Ws2812::new(spi);
   |                      ----------- ^^^ the trait `_embedded_hal_spi_FullDuplex<u8>` is not implemented for `Spi<stm32f0xx_hal::pac::SPI1, stm32f0xx_hal::gpio::gpioa::PA5<Alternate<stm32f0xx_hal::gpio::AF0>>, stm32f0xx_hal::gpio::gpioa::PA6<Alternate<stm32f0xx_hal::gpio::AF0>>, stm32f0xx_hal::gpio::gpioa::PA7<Alternate<stm32f0xx_hal::gpio::AF0>>, EightBit>`
   |                      |
   |                      required by a bound introduced by this call
   |
note: required by a bound in `ws2812_spi::Ws2812::<SPI>::new`
  --> /home/andrei/.cargo/registry/src/github.com-1ecc6299db9ec823/ws2812-spi-0.4.0/src/lib.rs:49:10
   |
49 |     SPI: FullDuplex<u8, Error = E>,
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ws2812_spi::Ws2812::<SPI>::new`
```

However `embedded_hal::blocking::spi::Write` is implemented. This implementation should be available for all FullDuplex implementations:

https://docs.rs/embedded-hal/latest/embedded_hal/blocking/spi/write/trait.Default.html

## Testing

Compiled and ran examples on a STM32F030C8Tx, observed LED examples worked well.
Compiled other targets and observed compilation finished (did not run, however this seems to confirm that Write trait is implemented where previously FullDuplex was provided).
