### PR TITLE
Optionally include reset sequences in prerendered transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add a `reset_single_transaction` feature for the `prerendered` version, which uses a single SPI transaction for a `write` call. Can be useful if using a DMA-approach or you're experiencing glitches due to the SPI peripheral turning high between the data and the reset.
+
+### Changed
+- Using the `mosi_idle_high` feature with the `prerendered` version now sends out the first reset together with the data, thus requiring a larger data buffer (but avoids potentially long dead-time between the first reset and the data being sent).
 
 ## [0.5.0] - 2024-07-29
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,6 @@ embedded-hal = "1.0.0"
 
 [features]
 mosi_idle_high = []
+# Send the reset command in one single transaction
+reset_single_transaction = []
 std = []

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It provides three variants:
   It may also be a timing issue with the first bit being sent, this is the case
   on the stm32f030 with 2MHz.
 
-  You could try using the `mosi_idle_high` feature, it might help.
+  You could try using the `mosi_idle_high` and `reset_single_transaction` features, they might help.
 
   If this does not help you can try different `embedded_hal::spi::Mode` parameters. For example on
   stm32f411 (as used for example on the Black Pill board) you have to set `phase` to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ where
         Ok(())
     }
 
-    fn flush(&mut self) -> Result<(), E> {
+    fn reset(&mut self) -> Result<(), E> {
         // Should be > 300μs, so for an SPI Freq. of 3.8MHz, we have to send at least 1140 low bits or 140 low bytes
         for _ in 0..140 {
             self.spi.write(from_ref(&0))?;
@@ -126,7 +126,7 @@ where
         I: Into<Self::Color>,
     {
         if cfg!(feature = "mosi_idle_high") {
-            self.flush()?;
+            self.reset()?;
         }
 
         for item in iterator {
@@ -135,7 +135,7 @@ where
             self.write_byte(item.r)?;
             self.write_byte(item.b)?;
         }
-        self.flush()?;
+        self.reset()?;
         Ok(())
     }
 }
@@ -153,7 +153,7 @@ where
         I: Into<Self::Color>,
     {
         if cfg!(feature = "mosi_idle_high") {
-            self.flush()?;
+            self.reset()?;
         }
 
         for item in iterator {
@@ -163,7 +163,7 @@ where
             self.write_byte(item.b)?;
             self.write_byte(item.a.0)?;
         }
-        self.flush()?;
+        self.reset()?;
         Ok(())
     }
 }

--- a/src/prerendered.rs
+++ b/src/prerendered.rs
@@ -11,7 +11,7 @@ use core::marker::PhantomData;
 
 use smart_leds_trait::{SmartLedsWrite, RGB8, RGBW};
 
-const FLUSH_DATA_LEN: usize = 140;
+const RESET_DATA_LEN: usize = 140;
 
 /// SPI mode that can be used for this crate
 ///
@@ -124,10 +124,10 @@ where
     /// Add a reset sequence (140 zeroes) to the data buffer
     // Is always used for `mosi_idle_high`, as otherwise the time required to fill the buffer can lead to idle cycles on the SPI bus
     fn write_reset(&mut self) -> Result<(), Error<E>> {
-        if self.index + FLUSH_DATA_LEN > self.data.len() {
+        if self.index + RESET_DATA_LEN > self.data.len() {
             return Err(Error::OutOfBounds);
         }
-        for _ in 0..FLUSH_DATA_LEN {
+        for _ in 0..RESET_DATA_LEN {
             self.data[self.index] = 0;
             self.index += 1;
         }
@@ -136,7 +136,7 @@ where
 
     /// Send a reset sequence (140 zeroes) on the bus
     fn send_reset(&mut self) -> Result<(), Error<E>> {
-        for _ in 0..FLUSH_DATA_LEN {
+        for _ in 0..RESET_DATA_LEN {
             self.spi.write(&[0]).map_err(Error::Spi)?;
         }
 


### PR DESCRIPTION
Based on #39, also:
- Fixes final reset without `reset_single_transaction`
- Always write the (optional) first reset into the buffer (THIS IS IMHO A BREAKING CHANGE, as the data array needs to be larger) 
- Various documentation stuff I noticed along the way

Closes #39

@jbeaurivage Does this still work for you?